### PR TITLE
Hook + Add External Jobs

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -382,7 +382,7 @@ Citizen.CreateThread(function()
 		local zone     = nil
 
 		for k,v in pairs(Config.PublicZones) do
-			if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x then
+			if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x/2 then
 				isInPublicMarker = true
 				position = v.Teleport
 				zone = v

--- a/client/main.lua
+++ b/client/main.lua
@@ -18,6 +18,7 @@ local Blips = {}
 local JobBlips = {}
 local isInMarker = false
 local isInPublicMarker = false
+local isExternalJobsLoaded = false
 
 local hintToDisplay = "no hint to display"
 local onDuty = false
@@ -302,6 +303,23 @@ AddEventHandler('esx_jobs:spawnJobVehicle', function(spawnPoint, vehicle)
 			vehicleMaxHealth = GetVehicleEngineHealth(spawnedVehicle)
 		end
 	end)
+end)
+
+-- Load external registered jobs
+Citizen.CreateThread(function()
+	while not isExternalJobsLoaded do
+		Citizen.Wait(1000)
+
+		ESX.TriggerServerCallback('esx_jobs:getExternalJobs', function(jobs)
+			if not isExternalJobsLoaded then
+				for jobKey, jobValues in pairs(jobs) do
+  					Config.Jobs[jobKey] = jobValues
+				end
+
+				isExternalJobsLoaded = true
+			end
+		end)
+	end
 end)
 
 -- Show top left hint

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,6 +2,7 @@ local PlayersWorking = {}
 ESX = nil
 
 local External = {
+	Jobs = {},
 	Hooks = {
 		overrides = {
 			add_item = {},
@@ -97,6 +98,21 @@ AddEventHandler('esx_jobs:registerHook', function(hType, hAction, hFunction)
 	else
 		print(hType .. ' ' .. hAction .. ' is not a valid hook')
 	end
+end)
+
+RegisterServerEvent('esx_jobs:registerExternalJobs')
+AddEventHandler('esx_jobs:registerExternalJobs', function(jobs)	
+	for jobKey, jobValues in pairs(jobs) do
+		if not External.Jobs[jobKey] then
+			External.Jobs[jobKey] = jobValues
+		else
+			print(jobKey .. ' is already a job on this server')
+		end		
+	end
+end)
+
+ESX.RegisterServerCallback("esx_jobs:getExternalJobs", function(source, cb)
+    cb(External.Jobs)
 end)
 
 RegisterServerEvent('esx_jobs:startWork')


### PR DESCRIPTION
The goal of theses implementations is to allow other resources to use the esx_jobs.

### Context
I'm working to implement a system that will add features to esx_jobs. In the game exploiting a resource (i.e: oil) will require to increase a skill. The first time a player tries to do something (i.e: gathering oil), he will fail but his skill will increase. More he's doing the job, more the skill increase. More the skill is high more he has the chance to get the resource and can get more than one resource at a time. I'm implementing more logic in that code. I'm planning to write a README but I'm too exited by writhing the code for the moment.

To do that, I want to use your module but keeping all the skill logic in my module. Then, if a server admin does want to use it, he just have to add the module and if he finally doesn't want it, he just need to remove it. I don't want to ask people to modify esx_jobs to be able to use my mod.

To do that I need to implement two simple features to it. Hooks and External jobs. The implementation is very light and has no effect on the actual functionalities.

Here is the description of the two features that has been implemented in that pull request (I have them in two different branches if you prefer to have two pull requests):

### Hook
This feature allows to register a function that will be called at a specific time. Two types of hooks can be registered: _override_ and _callback_

**Override hook**
An override hook will replace a part of the code. In that request I've implemented two override hooks: 
- [Confirm if the job action is a success](https://github.com/ESX-Org/esx_jobs/compare/master...KarmaUnderground:master#diff-210d026ec1c3ab3e93f2feb110259cfeR48) 
- [Payback the player for a resource](https://github.com/ESX-Org/esx_jobs/compare/master...KarmaUnderground:master#diff-210d026ec1c3ab3e93f2feb110259cfeR61)

**Callback**
A callback override is an addition of the actual code.  In that request I've implemented two callback hooks:
- [After the job action](https://github.com/ESX-Org/esx_jobs/compare/master...KarmaUnderground:master#diff-210d026ec1c3ab3e93f2feb110259cfeR59)
- [After the resource payback](https://github.com/ESX-Org/esx_jobs/compare/master...KarmaUnderground:master#diff-210d026ec1c3ab3e93f2feb110259cfeR65)

**Usage**
```
TriggerEvent('esx_jobs:registerHook', "overrides", "add_item", function (params)
    local xPlayer = params.xPlayer
    local item = params.item

    -- Do whatever you want
end)
```

### External Jobs
This feature allows a resource to add an array of jobs without having to change anything in the esx_jobs. The jobs will be added to the actual jobs defined in the esx_jobs resource

**Usage**
```
Jobs.mynewjob = {
	BlipInfos = {
		Sprite = 436,
		Color = 5
	},
	Vehicles = {
		Truck = {
			Spawner = 1,
-- And all the rest of the information

TriggerEvent('esx_jobs:registerExternalJobs', transform_job_2_esx_jobs(Jobs))
```

### Finaly

You can look at my resource here:
https://github.com/KarmaUnderground/ku_jobs_skills

I named my resource ku_jobs_skills but it could have been named esx_job_skills because it's totally liked to your esx series of resources.

Thanks!