### PR TITLE
Vehicle spawns with %100 fuel

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -245,7 +245,8 @@ AddEventHandler('esx_jobs:spawnJobVehicle', function(spawnPoint, vehicle)
 
 		TaskWarpPedIntoVehicle(playerPed, spawnedVehicle, -1)
 		Citizen.Wait(1)
-		exports["LegacyFuel"]:SetFuel(vehicle, 100)
+		SetVehicleFuelLevel(vehicle, 100.0)
+		DecorSetFloat(vehicle, "_FUEL_LEVEL", GetVehicleFuelLevel(vehicle))
 
 		if vehicle.HasCaution then
 			vehicleInCaseofDrop = spawnedVehicle

--- a/client/main.lua
+++ b/client/main.lua
@@ -244,6 +244,8 @@ AddEventHandler('esx_jobs:spawnJobVehicle', function(spawnPoint, vehicle)
 		myPlate[plate] = true
 
 		TaskWarpPedIntoVehicle(playerPed, spawnedVehicle, -1)
+		Citizen.Wait(1)
+		exports["LegacyFuel"]:SetFuel(vehicle, 100)
 
 		if vehicle.HasCaution then
 			vehicleInCaseofDrop = spawnedVehicle


### PR DESCRIPTION
On Jobs Vehicles spawn with random fuel level creates problem for players.
This little fix from Legacy fuel solve that problem.