### PR TITLE
Fix Last Commit Circa 2019

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -84,7 +84,7 @@ function OpenMenu()
 	end)
 end
 
-AddEventHandler('esx_jobs:action', function(job, zone)
+AddEventHandler('esx_jobs:action', function(job, zone, zoneKey)
 	menuIsShowed = true
 	if zone.Type == "cloakroom" then
 		OpenMenu()
@@ -96,7 +96,7 @@ AddEventHandler('esx_jobs:action', function(job, zone)
 		if IsPedInAnyVehicle(playerPed, false) then
 			ESX.ShowNotification(_U('foot_work'))
 		else
-			TriggerServerEvent('esx_jobs:startWork', zone.Item)
+			TriggerServerEvent('esx_jobs:startWork', zone.Item, zoneKey)
 		end
 	elseif zone.Type == "vehspawner" then
 		local spawnPoint = nil
@@ -469,7 +469,7 @@ Citizen.CreateThread(function()
 
 				if IsControlJustReleased(0, Keys['E']) and not menuIsShowed and isInMarker then
 					if onDuty or zone.Type == "cloakroom" or PlayerData.job.name == "reporter" then
-						TriggerEvent('esx_jobs:action', job, zone)
+						TriggerEvent('esx_jobs:action', job, zone, currentZone)
 					end
 				end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -77,7 +77,7 @@ Citizen.CreateThread(function()
 end)
 
 RegisterServerEvent('esx_jobs:startWork')
-AddEventHandler('esx_jobs:startWork', function(zoneIndex)
+AddEventHandler('esx_jobs:startWork', function(zoneIndex, zoneKey)
 	if not playersWorking[source] then
 		local xPlayer = ESX.GetPlayerFromId(source)
 
@@ -85,7 +85,7 @@ AddEventHandler('esx_jobs:startWork', function(zoneIndex)
 			local jobObject = Config.Jobs[xPlayer.job.name]
 
 			if jobObject then
-				local jobZone = jobObject.Zones[zoneIndex]
+				local jobZone = jobObject.Zones[zoneKey]
 
 				if jobZone and jobZone.Item then
 					playersWorking[source] = {


### PR DESCRIPTION
In the last commit to master, security was added to `esx_jobs:startWork` that has broken it entirely.
I discovered this while helping a friend with an install. When they reached a `work` zone, they'd never receive items.
The issue is server/main.lua#L88. zoneIndex is expected to be a table key, but is instead the item table.
This PR carries the key along with the table to fix it.