### PR TITLE
Fix: Argument was missing in startWork (delivery)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -195,7 +195,7 @@ AddEventHandler('esx_jobs:action', function(job, zone, zoneKey)
 
 		hintToDisplay = "no hint to display"
 		hintIsShowed = false
-		TriggerServerEvent('esx_jobs:startWork', zone.Item)
+		TriggerServerEvent('esx_jobs:startWork', zone.Item, zoneKey)
 	end
 	--nextStep(zone.GPS)
 end)


### PR DESCRIPTION
There was a missing argument and people weren't able to get the delivery item at the end of their work